### PR TITLE
add some parts to allow better styling 

### DIFF
--- a/js/packages/web/src/components/canary-reference.ts
+++ b/js/packages/web/src/components/canary-reference.ts
@@ -29,6 +29,7 @@ export class CanaryReference extends LitElement {
   render() {
     return html`
       <button
+        part="button"
         @click=${this._handleClick}
         class=${classMap({ container: true, selected: this.selected })}
       >

--- a/js/packages/web/src/components/canary-search-references.ts
+++ b/js/packages/web/src/components/canary-search-references.ts
@@ -46,7 +46,7 @@ export class CanarySearchReferences extends LitElement {
 
       if (group.title === null || group.sub_results.length < 2) {
         return html`
-          <div class="group single">
+          <div class="group single" part="group">
             ${group.sub_results.map(
               ({ url, title, excerpt }) => html`
                 <canary-reference
@@ -63,7 +63,7 @@ export class CanarySearchReferences extends LitElement {
       }
 
       return html`
-        <div class="group multiple">
+        <div class="group multiple" part="group">
           <canary-reference
             mode="parent"
             url=${stripURL(group.url)}

--- a/js/packages/web/src/components/canary-search-results-tabs.ts
+++ b/js/packages/web/src/components/canary-search-results-tabs.ts
@@ -83,7 +83,7 @@ export class CanarySearchResultsTabs extends LitElement {
 
     return html`
       <div class="container">
-        <div class="tab-container">
+        <div class="tab-container" part="tab-container">
           <canary-tabs-url
             .tabs=${this.tabs.map(({ name }) => name)}
             .selected=${this._selectedTab}

--- a/js/packages/web/src/components/canary-search.ts
+++ b/js/packages/web/src/components/canary-search.ts
@@ -32,7 +32,7 @@ export class CanarySearch extends LitElement {
       ? nothing
       : html`
           <div class="container">
-            <div class="scroll-container" ${ref(this._containerRef)}>
+            <div part="scroll-container" class="scroll-container" ${ref(this._containerRef)}>
               <div class="body">
                 <slot name="body"></slot>
               </div>

--- a/js/packages/web/src/components/canary-tabs-url.ts
+++ b/js/packages/web/src/components/canary-tabs-url.ts
@@ -15,7 +15,7 @@ export class CanaryTabsUrl extends LitElement {
         ${this.tabs.map((name) => {
           const selected = name === this.selected;
 
-          return html`<div @click=${() => this._handleChangeTab(name)}>
+          return html`<div part="tab-item" @click=${() => this._handleChangeTab(name)}>
             <input
               type="radio"
               name="mode"
@@ -23,7 +23,7 @@ export class CanaryTabsUrl extends LitElement {
               .value=${name}
               ?checked=${selected}
             />
-            <label class=${classMap({ tab: true, selected })}> ${name} </label>
+            <label class=${classMap({ tab: true, selected })} part="label"> ${name} </label>
           </div>`;
         })}
       </div>


### PR DESCRIPTION
To have more options about styling the whole search component, I added some parts.

For `canary-search`:

Here I have added the part `scroll-container`. This allows me/us to customize the complete outer div ( e.g. using a different padding )

For `canary-search-references`:

Here I have added the part `group` to both group definitions

For `canary-reference`:

Here I have added the part `button` since this is the outer layer for each search result.

I think this should be enough to create a custom styling for the search results.

---

Added also some parts to the tab components.

Is it possible to have a conditional part value?
Example: If a tab is active, it should have `part="tab-item-active"` otherwise, it becomes `part="tab-item"`.
