### PR TITLE
feat(132): add transition attribute to canary-modal open/close

### DIFF
--- a/js/packages/web/.changeset/healthy-squids-jog.md
+++ b/js/packages/web/.changeset/healthy-squids-jog.md
@@ -1,0 +1,5 @@
+---
+"@getcanary/web": patch
+---
+
+Add transition effects to the canary-modal component

--- a/js/packages/web/src/components/canary-dialog.ts
+++ b/js/packages/web/src/components/canary-dialog.ts
@@ -8,16 +8,19 @@ const NAME = "canary-dialog";
 
 /**
  * @cssprop --canary-color-backdrop-overlay - Backdrop overlay color
+ * @cssprop --canary-transition-duration - Duration of modal transition
+ * @cssprop --canary-transition-timing - Timing function of modal transition
  * @slot - Default slot
  */
 @registerCustomElement(NAME)
 export class CanaryDialog extends LitElement {
   @property({ attribute: false })
+  @property({ type: Boolean }) transition = false;
   ref: Ref<HTMLDialogElement> = createRef();
 
   render() {
     return html`
-      <dialog ${ref(this.ref)} @click=${this.handleClick}>
+      <dialog ${ref(this.ref)} class=${this.transition ? 'with-transition' : ''} @click=${this.handleClick}>
         <slot></slot>
       </dialog>
     `;
@@ -48,6 +51,21 @@ export class CanaryDialog extends LitElement {
         box-shadow:
           0 20px 25px -5px rgb(0 0 0 / 0.1),
           0 8px 10px -6px rgb(0 0 0 / 0.1);
+      }
+
+      dialog.with-transition {
+        transition: opacity var(--canary-transition-duration, 0.5s) var(--canary-transition-timing, ease-in-out),
+                    transform var(--canary-transition-duration, 0.5s) var(--canary-transition-timing, ease-in-out);
+      }
+
+      dialog.with-transition[open] {
+        opacity: 1;
+        transform: translateY(0);
+      }
+
+      dialog.with-transition:not([open]) {
+        opacity: 0;
+        transform: translateY(-20px);
       }
     `,
   ];

--- a/js/packages/web/src/components/canary-dialog.ts
+++ b/js/packages/web/src/components/canary-dialog.ts
@@ -23,7 +23,6 @@ export class CanaryDialog extends LitElement {
     const canaryDialogClasses = {
       "with-transition": this.transition,
     };
-    console.log("transition in canary-dialog.ts: ", this.transition);
 
     return html`
       <dialog
@@ -64,22 +63,25 @@ export class CanaryDialog extends LitElement {
       }
 
       dialog.with-transition {
-        border: 1px solid red;
         transition:
-          opacity var(--canary-transition-duration, 0.3s)
-            var(--canary-transition-timing, ease-in-out),
-          transform var(--canary-transition-duration, 0.3s)
-            var(--canary-transition-timing, ease-in-out);
+          opacity var(--canary-transition-duration, 0.5s)
+            var(--canary-transition-timing, allow-discrete),
+          transform var(--canary-transition-duration, 0.5s)
+            var(--canary-transition-timing, allow-discrete);
       }
 
       dialog.with-transition[open] {
         opacity: 1;
-        transform: translateY(0);
       }
 
       dialog.with-transition:not([open]) {
         opacity: 0;
-        transform: translateY(-20px);
+      }
+
+      @starting-style {
+        dialog.with-transition[open] {
+          opacity: 0;
+        }
       }
     `,
   ];

--- a/js/packages/web/src/components/canary-dialog.ts
+++ b/js/packages/web/src/components/canary-dialog.ts
@@ -23,6 +23,7 @@ export class CanaryDialog extends LitElement {
     const canaryDialogClasses = {
       "with-transition": this.transition,
     };
+    console.log("transition in canary-dialog.ts: ", this.transition);
 
     return html`
       <dialog
@@ -63,10 +64,11 @@ export class CanaryDialog extends LitElement {
       }
 
       dialog.with-transition {
+        border: 1px solid red;
         transition:
-          opacity var(--canary-transition-duration, 0.5s)
+          opacity var(--canary-transition-duration, 0.3s)
             var(--canary-transition-timing, ease-in-out),
-          transform var(--canary-transition-duration, 0.5s)
+          transform var(--canary-transition-duration, 0.3s)
             var(--canary-transition-timing, ease-in-out);
       }
 

--- a/js/packages/web/src/components/canary-dialog.ts
+++ b/js/packages/web/src/components/canary-dialog.ts
@@ -1,8 +1,8 @@
 import { LitElement, css, html } from "lit";
 import { property } from "lit/decorators.js";
-
 import { registerCustomElement } from "../decorators";
 import { ref, createRef, Ref } from "lit/directives/ref.js";
+import { classMap } from "lit/directives/class-map.js";
 
 const NAME = "canary-dialog";
 
@@ -15,12 +15,21 @@ const NAME = "canary-dialog";
 @registerCustomElement(NAME)
 export class CanaryDialog extends LitElement {
   @property({ attribute: false })
-  @property({ type: Boolean }) transition = false;
+  @property({ type: Boolean })
+  transition = false;
   ref: Ref<HTMLDialogElement> = createRef();
 
   render() {
+    const canaryDialogClasses = {
+      "with-transition": this.transition,
+    };
+
     return html`
-      <dialog ${ref(this.ref)} class=${this.transition ? 'with-transition' : ''} @click=${this.handleClick}>
+      <dialog
+        ${ref(this.ref)}
+        class=${classMap(canaryDialogClasses)}
+        @click=${this.handleClick}
+      >
         <slot></slot>
       </dialog>
     `;
@@ -54,8 +63,11 @@ export class CanaryDialog extends LitElement {
       }
 
       dialog.with-transition {
-        transition: opacity var(--canary-transition-duration, 0.5s) var(--canary-transition-timing, ease-in-out),
-                    transform var(--canary-transition-duration, 0.5s) var(--canary-transition-timing, ease-in-out);
+        transition:
+          opacity var(--canary-transition-duration, 0.5s)
+            var(--canary-transition-timing, ease-in-out),
+          transform var(--canary-transition-duration, 0.5s)
+            var(--canary-transition-timing, ease-in-out);
       }
 
       dialog.with-transition[open] {

--- a/js/packages/web/src/components/canary-modal.ts
+++ b/js/packages/web/src/components/canary-modal.ts
@@ -19,9 +19,11 @@ export class CanaryModal extends LitElement {
   private _ref = createRef<HTMLDialogElement>();
 
   render() {
+    console.log("transition in canary-modal.ts: ", this.transition);
+
     return html`
       <slot name="trigger" @click=${this._handleOpen}></slot>
-      <canary-dialog .ref=${this._ref} ?transition=${this.transition}>
+      <canary-dialog .ref=${this._ref} .transition=${this.transition}>
         <slot name="content" @modal-close=${this._handleModalClose}></slot>
       </canary-dialog>
     `;

--- a/js/packages/web/src/components/canary-modal.ts
+++ b/js/packages/web/src/components/canary-modal.ts
@@ -19,8 +19,6 @@ export class CanaryModal extends LitElement {
   private _ref = createRef<HTMLDialogElement>();
 
   render() {
-    console.log("transition in canary-modal.ts: ", this.transition);
-
     return html`
       <slot name="trigger" @click=${this._handleOpen}></slot>
       <canary-dialog .ref=${this._ref} .transition=${this.transition}>

--- a/js/packages/web/src/components/canary-modal.ts
+++ b/js/packages/web/src/components/canary-modal.ts
@@ -14,13 +14,14 @@ export const MODAL_CLOSE_EVENT = "modal-close";
 @registerCustomElement(NAME)
 export class CanaryModal extends LitElement {
   @property({ type: Boolean }) open = false;
+  @property({ type: Boolean }) transition = false;
 
   private _ref = createRef<HTMLDialogElement>();
 
   render() {
     return html`
       <slot name="trigger" @click=${this._handleOpen}></slot>
-      <canary-dialog .ref=${this._ref}>
+      <canary-dialog .ref=${this._ref} ?transition=${this.transition}>
         <slot name="content" @modal-close=${this._handleModalClose}></slot>
       </canary-dialog>
     `;

--- a/js/packages/web/src/stories/canary-modal.stories.ts
+++ b/js/packages/web/src/stories/canary-modal.stories.ts
@@ -41,3 +41,35 @@ export const Default: StoryObj = {
     await userEvent.click(trigger);
   },
 };
+
+export const OpenWithTransition: StoryObj = {
+  args: {},
+  render: () => {
+    return html`
+      <canary-modal
+        transition
+        style="
+          --canary-transition-duration: 0.5s; 
+          --canary-transition-timing: ease;
+        "
+      >
+        <canary-trigger-searchbar
+          data-testid="trigger"
+          slot="trigger"
+        ></canary-trigger-searchbar>
+        <canary-content slot="content">
+          <canary-input slot="input"></canary-input>
+          <canary-search slot="mode">
+            <canary-search-results slot="body"></canary-search-results>
+          </canary-search>
+        </canary-content>
+      </canary-modal>
+    `;
+  },
+  play: async ({ canvasElement }) => {
+    const trigger = shadow.getByShadowTestId(canvasElement, "trigger");
+    await userEvent.click(trigger);
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  },
+};

--- a/js/packages/web/src/stories/canary-modal.stories.ts
+++ b/js/packages/web/src/stories/canary-modal.stories.ts
@@ -49,8 +49,8 @@ export const OpenWithTransition: StoryObj = {
       <canary-modal
         transition
         style="
-          --canary-transition-duration: 0.5s; 
-          --canary-transition-timing: ease;
+          --canary-transition-duration: 0.8s; 
+          --canary-transition-timing: ease-in-out;
         "
       >
         <canary-trigger-searchbar


### PR DESCRIPTION
fixes #132 
/claim #132 

#### Summary
This PR adds a transition property to the canary-modal and canary-dialog components, enabling smooth open/close animations. Transitions can be customized using CSS variables (--canary-transition-duration and --canary-transition-timing).

#### Usage
Enable transitions by setting the transition attribute on the modal, and customize with CSS variables if needed:
```
<canary-modal transition></canary-modal>
```
